### PR TITLE
Use curl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     dplyr (>= 1.0.0),
     tinytiger,
     sf,
-    withr
+    withr,
     foreign
 Suggests: 
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     sf,
     withr
     foreign
->>>>>>> main
 Suggests: 
     testthat (>= 3.0.0),
     lifecycle,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,13 +12,13 @@ Description: Tools to process legacy format summary redistricting data files
 Depends: R (>= 4.0.0)
 Imports: 
     cli,
+    curl,
     stringr,
     readr,
     dplyr (>= 1.0.0),
     tinytiger,
     sf,
-    withr,
-    httr
+    withr
 Suggests: 
     testthat (>= 3.0.0),
     lifecycle,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 download_census <- function(url, path) {
     tryCatch({
-        res = httr::GET(url = url, httr::write_disk(path))
-        res$status_code == 200L
+        res = curl::curl_download(url = url, destfile = path)
+        TRUE
     }, error = function(e) {
         cat("Error:", e$message, "\n")
         FALSE

--- a/man/PL94171-package.Rd
+++ b/man/PL94171-package.Rd
@@ -20,7 +20,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Cory McCartan \email{cmccartan@g.harvard.edu}
+\strong{Maintainer}: Cory McCartan \email{mccartan@psu.edu}
 
 Authors:
 \itemize{

--- a/tests/testthat/test-urls.R
+++ b/tests/testthat/test-urls.R
@@ -3,7 +3,7 @@ skip_on_cran()
 test_that("PL URLs are generated correctly", {
     wa10_url = "https://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/Washington/wa2010.pl.zip"
     expect_equal(pl_url("WA", 2010), wa10_url)
-    expect_true(httr::HEAD(pl_url("WA", 2000)[3])$all_headers[[1]]$status == 200)
-    expect_true(httr::HEAD(pl_url("DC", 2010))$all_headers[[1]]$status == 200)
-    expect_true(httr::HEAD(pl_url("IA", 2020))$all_headers[[1]]$status == 200)
+    expect_true(attr(curlGetHeaders(url = pl_url("WA", 2000)[3]), 'status') == 200)
+    expect_true(attr(curlGetHeaders(url = pl_url("DC", 2000)[3]), 'status') == 200)
+    expect_true(attr(curlGetHeaders(url = pl_url("IA", 2000)[3]), 'status') == 200)
 })


### PR DESCRIPTION
Implements a changeover from `httr` and adds missing devtools::document from last update.