### PR TITLE
Use subdirectory for `pl_url() |> pl_read()` pipeline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # PL94171 1.2.0
 * Adds support for 1990 data in `pl_url()` and `pl_read()`.
+* Fixes an error where repeatedly downloading and reading data in the same session would fail due to overuse of the same temporary file directory.
 
 # PL94171 1.1.3
 * Update documentation to fix NOTEs on CRAN

--- a/R/pl_read.R
+++ b/R/pl_read.R
@@ -68,13 +68,16 @@ pl_read = function(path, ...) {
             stop("Provide a single path to the directory containing the PL files.")
         }
     } else if (stringr::str_detect(path, "^(http://|https://|ftp://|ftps://)")) {
+        st_yr <- path |>
+            basename() |>
+            stringr::word(sep = stringr::fixed('.'))
         zip_path = withr::local_tempfile(pattern="pl", fileext=".zip")
         success = download_census(path, zip_path)
         if (!success) {
             message("Download did not succeed. Try again.")
             return(NULL)
         }
-        zip_dir = file.path(dirname(zip_path), "PL-unzip")
+        zip_dir = file.path(dirname(zip_path), "PL-unzip", st_yr)
         utils::unzip(zip_path, exdir=zip_dir)
         path = zip_dir
     } else if (!dir.exists(path)) { # compressed file
@@ -84,7 +87,9 @@ pl_read = function(path, ...) {
     }
 
     files = list.files(path, pattern="\\.u?pl$", ignore.case=TRUE)
-    if (length(files) == 0) stop("No P.L. 94-171 files found in the provided directory.")
+    if (length(files) == 0) {
+        stop("No P.L. 94-171 files found in the provided directory.")
+    }
     out = list()
     ftypes = c("00001", "00002", "00003", "geo")
     for (fname in files) {


### PR DESCRIPTION
Repeated downloads otherwise unzip to the same directory. This explains the massive slowdown when downloading and reading the whole US, as *every* previously downloaded file would be re-read. Further, it running the same code in a single session would result in only the last state being reread repeatedly.